### PR TITLE
Add `requests` and `aiohttp` deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 version = "0.2"
 
-dependencies = ["fsspec", 'sourmash>=4.6.1,<5']
+dependencies = ["fsspec", "requests", "aiohttp", 'sourmash>=4.6.1,<5']
 
 [metadata]
 license = { text = "BSD 3-Clause License" }


### PR DESCRIPTION
While testing out https://github.com/sourmash-bio/sourmash/pull/2428, I experienced the following error with the `http` files:

```
sourmash sig describe https://raw.githubusercontent.com/sourmash-bio/sourmash_plugin_load_urls/main/tests/test-data/47.fa.sig


== This is sourmash version 4.6.1. ==
== Please cite Brown and Irber (2016), doi:10.21105/joss.00027. ==

Traceback (most recent call last):
  File "/Users/ntward/mambaforge/envs/sourmash_dev/lib/python3.9/site-packages/fsspec/registry.py", line 243, in get_filesystem_class
    register_implementation(protocol, _import_class(bit["class"]))
  File "/Users/ntward/mambaforge/envs/sourmash_dev/lib/python3.9/site-packages/fsspec/registry.py", line 266, in _import_class
    mod = importlib.import_module(mod)
  File "/Users/ntward/mambaforge/envs/sourmash_dev/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/Users/ntward/mambaforge/envs/sourmash_dev/lib/python3.9/site-packages/fsspec/implementations/http.py", line 11, in <module>
    import aiohttp
ModuleNotFoundError: No module named 'aiohttp'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/ntward/mambaforge/envs/sourmash_dev/bin/sourmash", line 8, in <module>
    sys.exit(main())
  File "/Users/ntward/mambaforge/envs/sourmash_dev/lib/python3.9/site-packages/sourmash/__main__.py", line 13, in main
    return mainmethod(args)
  File "/Users/ntward/mambaforge/envs/sourmash_dev/lib/python3.9/site-packages/sourmash/cli/sig/describe.py", line 60, in main
    return sourmash.sig.__main__.describe(args)
  File "/Users/ntward/mambaforge/envs/sourmash_dev/lib/python3.9/site-packages/sourmash/sig/__main__.py", line 243, in describe
    for sig, location in loader:
  File "/Users/ntward/mambaforge/envs/sourmash_dev/lib/python3.9/site-packages/sourmash/sourmash_args.py", line 639, in load_many_signatures
    idx = load_file_as_index(loc, yield_all_files=yield_all_files)
  File "/Users/ntward/mambaforge/envs/sourmash_dev/lib/python3.9/site-packages/sourmash/save_load.py", line 65, in load_file_as_index
    return _load_database(filename, yield_all_files)
  File "/Users/ntward/mambaforge/envs/sourmash_dev/lib/python3.9/site-packages/sourmash/save_load.py", line 113, in _load_database
    db = load_fn(filename,
  File "/Users/ntward/mambaforge/envs/sourmash_dev/lib/python3.9/site-packages/sourmash_plugin_load_urls.py", line 15, in load_sketches
    of = fsspec.open(location, 'rb')
  File "/Users/ntward/mambaforge/envs/sourmash_dev/lib/python3.9/site-packages/fsspec/core.py", line 441, in open
    return open_files(
  File "/Users/ntward/mambaforge/envs/sourmash_dev/lib/python3.9/site-packages/fsspec/core.py", line 273, in open_files
    fs, fs_token, paths = get_fs_token_paths(
  File "/Users/ntward/mambaforge/envs/sourmash_dev/lib/python3.9/site-packages/fsspec/core.py", line 621, in get_fs_token_paths
    cls = get_filesystem_class(protocol)
  File "/Users/ntward/mambaforge/envs/sourmash_dev/lib/python3.9/site-packages/fsspec/registry.py", line 245, in get_filesystem_class
    raise ImportError(bit["err"]) from e
ImportError: HTTPFileSystem requires "requests" and "aiohttp" to be installed
```

This PR adds `requests` and `aiohttp` to the `pyproject.toml` file. 